### PR TITLE
feat: New proxy option

### DIFF
--- a/.changeset/good-buckets-flash.md
+++ b/.changeset/good-buckets-flash.md
@@ -1,0 +1,5 @@
+---
+"@workleap/honeycomb": major
+---
+
+Rename the `endpoint` option for `proxy`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,7 +42,7 @@ import { createRoot } from "react-dom/client";
 import { App } from "./App.tsx";
 
 registerHoneycombInstrumentation(runtime, "sample", [/.+/g,], {
-    endpoint: "https://sample-collector"
+    proxy: "https://sample-proxy"
 });
 
 const root = createRoot(document.getElementById("root")!);
@@ -59,7 +59,7 @@ Avoid using `/.+/g,` in production, as it could expose customer data to third pa
 !!!
 
 !!!warning
-We recommend using an [OpenTelemetry collector](https://docs.honeycomb.io/send-data/opentelemetry/collector/) over an ingestion [API key](https://docs.honeycomb.io/get-started/configure/environments/manage-api-keys/#create-api-key), as API keys can expose Workleap to potential attacks.
+We recommend using an [OpenTelemetry collector](https://docs.honeycomb.io/send-data/opentelemetry/collector/) with an authenticated proxy over an ingestion [API key](https://docs.honeycomb.io/get-started/configure/environments/manage-api-keys/#create-api-key), as API keys can expose Workleap to potential attacks.
 !!!
 
 With instrumentation in place, a few traces are now available 👇
@@ -115,7 +115,7 @@ import { createRoot } from "react-dom/client";
 import { App } from "./App.tsx";
 
 registerHoneycombInstrumentation(runtime, "sample", [/.+/g,], {
-    endpoint: "https://sample-collector"
+    proxy: "https://sample-proxy"
 });
 
 setGlobalSpanAttribute("app.user_id", "123");

--- a/docs/reference/registerHoneycombInstrumentation.md
+++ b/docs/reference/registerHoneycombInstrumentation.md
@@ -17,7 +17,7 @@ registerHoneycombInstrumentation(serviceName, apiServiceUrls: [string | Regex], 
 ### Parameters
 
 - `serviceName`: Honeycomb application service name.
-- `apiServiceUrls`: A `RegExp` or `string` that matches the URLs of the application's backend services. If unsure, use the temporary regex `/.+/g,` to match all URLs.
+- `apiServiceUrls`: A `RegExp` or `string` that matches the URLs of the application's backend services. If unsure, start with the temporary regex `/.+/g,` to match all URLs.
 - `options`: An optional object literal of [predefined options](#predefined-options).
 
 ### Returns
@@ -47,7 +47,7 @@ import { registerHoneycombInstrumentation } from "@workleap/honeycomb";
 registerHoneycombInstrumentation(
     runtime, "sample", 
     [/https:\/\/workleap.com\/api\.*/], 
-    { endpoint: "https://sample-collector" }
+    { proxy: "https://sample-proxy" }
 );
 ```
 
@@ -55,28 +55,30 @@ registerHoneycombInstrumentation(
 
 The `registerHoneycombInstrumentation(serviceName, apiServiceUrls, options)` function can be used as shown in the previous example, however, if you wish to customize the default configuration, the function also accept a few predefined options to help with that 👇
 
-### `endpoint`
+### `proxy`
 
 - **Type**: `string`
 - **Default**: `undefined`
 
-Set the URL to an [OpenTelemetry collector](https://docs.honeycomb.io/send-data/opentelemetry/collector/). Either `endpoint` or `apiKey` option must be provided.
+Set the URL to an [OpenTelemetry collector](https://docs.honeycomb.io/send-data/opentelemetry/collector/) proxy. Either `proxy` or `apiKey` option must be provided.
 
 ```ts !#4
 import { registerHoneycombInstrumentation } from "@workleap/honeycomb";
 
 registerHoneycombInstrumentation(runtime, "sample", [/.+/g,], {
-    endpoint: "https://sample-collector"
+    proxy: "https://sample-proxy"
 });
 ```
+
+When a `proxy` option is provided, the current session credentials are automatically sent with the OTel trace requests.
 
 ### `apiKey`
 
 !!!warning
-Prefer using an [OpenTelemetry collector](https://docs.honeycomb.io/send-data/opentelemetry/collector/) over an ingestion [API key](https://docs.honeycomb.io/get-started/configure/environments/manage-api-keys/#create-api-key), as API keys can expose Workleap to potential attacks.
+Prefer using an [OpenTelemetry collector](https://docs.honeycomb.io/send-data/opentelemetry/collector/) with an authenticated proxy over an ingestion [API key](https://docs.honeycomb.io/get-started/configure/environments/manage-api-keys/#create-api-key), as API keys can expose Workleap to potential attacks.
 !!!
 
-Set an Honeycomb ingestion [API key](https://docs.honeycomb.io/get-started/configure/environments/manage-api-keys/#create-api-key). Either `endpoint` or `apiKey` option must be provided.
+Set an Honeycomb ingestion [API key](https://docs.honeycomb.io/get-started/configure/environments/manage-api-keys/#create-api-key). Either `proxy` or `apiKey` option must be provided.
 
 - **Type**: `string`
 - **Default**: `undefined`
@@ -101,7 +103,7 @@ import { registerHoneycombInstrumentation } from "@workleap/honeycomb";
 import { LongTaskInstrumentation } from "@opentelemetry/instrumentation-long-task";
 
 registerHoneycombInstrumentation(runtime, "sample", [/.+/g,], {
-    endpoint: "https://sample-collector",
+    proxy: "https://sample-proxy",
     instrumentations: [
         new LongTaskInstrumentation()
     ]
@@ -140,7 +142,7 @@ import { registerHoneycombInstrumentation } from "@workleap/honeycomb";
 import { CustomSpanProcessor } from "./CustomSpanProcessor.ts";
 
 registerHoneycombInstrumentation(runtime, "sample", [/.+/g,], {
-    endpoint: "https://sample-collector",
+    proxy: "https://sample-proxy",
     spanProcessors: [
         new CustomSpanProcessor()
     ]
@@ -158,7 +160,7 @@ Replace the default [@opentelemetry/instrumentation-fetch](https://github.com/op
 import { registerHoneycombInstrumentation } from "@workleap/honeycomb";
 
 registerHoneycombInstrumentation(runtime, "sample", [/.+/g,], {
-    endpoint: "https://sample-collector",
+    proxy: "https://sample-proxy",
     fetchInstrumentation: (defaultOptions) => {
         return {
             ...defaultOptions,
@@ -174,7 +176,7 @@ To disable [@opentelemetry/instrumentation-fetch](https://github.com/open-teleme
 import { registerHoneycombInstrumentation } from "@workleap/honeycomb";
 
 registerHoneycombInstrumentation(runtime, "sample", [/.+/g,], {
-    endpoint: "https://sample-collector",
+    proxy: "https://sample-proxy",
     fetchInstrumentation: false
 });
 ```
@@ -190,7 +192,7 @@ Replace the default [@opentelemetry/instrumentation-document-load](https://githu
 import { registerHoneycombInstrumentation } from "@workleap/honeycomb";
 
 registerHoneycombInstrumentation(runtime, "sample", [/.+/g,], {
-    endpoint: "https://sample-collector",
+    proxy: "https://sample-proxy",
     documentLoadInstrumentation: (defaultOptions) => {
         return {
             ...defaultOptions,
@@ -206,7 +208,7 @@ To disable [@opentelemetry/instrumentation-document-load](https://github.com/ope
 import { registerHoneycombInstrumentation } from "@workleap/honeycomb";
 
 registerHoneycombInstrumentation(runtime, "sample", [/.+/g,], {
-    endpoint: "https://sample-collector",
+    proxy: "https://sample-proxy",
     documentLoadInstrumentation: (defaultOptions) => {
         return {
             ...defaultOptions,
@@ -227,7 +229,7 @@ By default, [@opentelemetry/instrumentation-xml-http-request](https://github.com
 import { registerHoneycombInstrumentation } from "@workleap/honeycomb";
 
 registerHoneycombInstrumentation(runtime, "sample", [/.+/g,], {
-    endpoint: "https://sample-collector",
+    proxy: "https://sample-proxy",
     xmlHttpRequestInstrumentation: (defaultOptions) => {
         return {
             ...defaultOptions,
@@ -243,7 +245,7 @@ Or set the option to `true` to enable [@opentelemetry/instrumentation-xml-http-r
 import { registerHoneycombInstrumentation } from "@workleap/honeycomb";
 
 registerHoneycombInstrumentation(runtime, "sample", [/.+/g,], {
-    endpoint: "https://sample-collector",
+    proxy: "https://sample-proxy",
     xmlHttpRequestInstrumentation: true
 });
 ```
@@ -259,7 +261,7 @@ By default, [@opentelemetryinstrumentation-user-interaction](https://github.com/
 import { registerHoneycombInstrumentation } from "@workleap/honeycomb";
 
 registerHoneycombInstrumentation(runtime, "sample", [/.+/g,], {
-    endpoint: "https://sample-collector",
+    proxy: "https://sample-proxy",
     userInteractionInstrumentation: (defaultOptions) => {
         return {
             ...defaultOptions,
@@ -275,7 +277,7 @@ Or set the option to `true` to enable [@opentelemetryinstrumentation-user-intera
 import { registerHoneycombInstrumentation } from "@workleap/honeycomb";
 
 registerHoneycombInstrumentation(runtime, "sample", [/.+/g,], {
-    endpoint: "https://sample-collector",
+    proxy: "https://sample-proxy",
     userInteractionInstrumentation: true
 });
 ```
@@ -291,7 +293,7 @@ Indicates whether or not debug information should be logged to the console.
 import { registerHoneycombInstrumentation } from "@workleap/honeycomb";
 
 registerHoneycombInstrumentation(runtime, "sample", [/.+/g,], {
-    endpoint: "https://sample-collector",
+    proxy: "https://sample-proxy",
     debug: true
 });
 ```
@@ -325,7 +327,7 @@ const skipOptionsValidationTransformer: HoneycombSdkOptionsTransformer = config 
 }
 
 registerHoneycombInstrumentation(runtime, "sample", [/.+/g,], {
-    endpoint: "https://sample-collector",
+    proxy: "https://sample-proxy",
     transformers: [skipOptionsValidationTransformer]
 });
 ```

--- a/docs/sample.md
+++ b/docs/sample.md
@@ -3,7 +3,15 @@ order: 10
 icon: command-palette
 ---
 
-# Sample
+# Samples
 
-- :icon-mark-github: [Frontend application](https://github.com/gsoft-inc/wl-honeycomb-web/tree/main/sample/app)
-- :icon-mark-github: [Server](https://github.com/gsoft-inc/wl-honeycomb-web/tree/main/sample/express-server)
+With an ingestion API key: 
+
+- :icon-mark-github: [Frontend application](https://github.com/gsoft-inc/wl-honeycomb-web/tree/main/samples/api-key/app)
+- :icon-mark-github: [Server](https://github.com/gsoft-inc/wl-honeycomb-web/tree/main/samples/api-key/express-server)
+
+With a proxy:
+
+- :icon-mark-github: [Frontend application](https://github.com/gsoft-inc/wl-honeycomb-web/tree/main/samples/proxy/app)
+- :icon-mark-github: [Proxy](https://github.com/gsoft-inc/wl-honeycomb-web/tree/main/samples/proxy/express-proxy)
+- :icon-mark-github: [Server](https://github.com/gsoft-inc/wl-honeycomb-web/tree/main/samples/proxy/express-server)

--- a/lib/src/assertions.ts
+++ b/lib/src/assertions.ts
@@ -1,0 +1,3 @@
+export function isString(value: unknown): value is string {
+    return Object.prototype.toString.call(value) === "[object String]";
+}

--- a/lib/src/patchXmlHttpRequest.ts
+++ b/lib/src/patchXmlHttpRequest.ts
@@ -1,0 +1,31 @@
+import { isString } from "./assertions.ts";
+
+// Patching: https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/otlp-exporter-base/src/transport/xhr-transport.ts
+//
+// Explanations:
+//      1) Currently, all trace requests initiated by OTel automatic instrumentation is sent through XMR.
+//      2) Current issue is that there's no option to tell OTel automatic instrumentation to include the user credentials. Our collector proxy implementation needs those credentials to authenticate the requests.
+//      3) To circumvent this limitation, we patch XMR to include the credentials when the request is sent to configured proxy URL.
+//
+// If OTel automatic instrumentation transportation switch to the Fetch API, the following article could help patching the Fetch API: https://blog.logrocket.com/intercepting-javascript-fetch-api-requests-responses/
+export function patchXmlHttpRequest(proxy: string) {
+    const originalOpen = XMLHttpRequest.prototype.open;
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    XMLHttpRequest.prototype.open = function(...args) {
+        const url = args[1];
+
+        if (url && proxy) {
+            const stringifyUrl = isString(url) ? url : url.toString();
+
+            if (stringifyUrl.includes(proxy)) {
+                this.withCredentials = true;
+            }
+        }
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        originalOpen.apply(this, args);
+    };
+}

--- a/lib/tests/getHoneycombSdkOptions.test.ts
+++ b/lib/tests/getHoneycombSdkOptions.test.ts
@@ -82,13 +82,13 @@ test("do not throw when an api key is provided", () => {
     })).not.toThrow();
 });
 
-test("do not throw when an endpoint is provided", () => {
+test("do not throw when a proxy is provided", () => {
     expect(() => getHoneycombSdkOptions("foo", ["/foo"], {
-        endpoint: "https://www.google.com"
+        proxy: "https://my-proxy.com"
     })).not.toThrow();
 });
 
-test("throw when both the api key and endpoint options are not provided", () => {
+test("throw when both the api key and proxy options are not provided", () => {
     expect(() => getHoneycombSdkOptions("foo", ["/foo"])).toThrow();
 });
 

--- a/samples/proxy/app/src/index.tsx
+++ b/samples/proxy/app/src/index.tsx
@@ -4,7 +4,7 @@ import { createRoot } from "react-dom/client";
 import { App } from "./App.tsx";
 
 registerHoneycombInstrumentation("honeycomb-proxy-sample", [/http:\/\/localhost:1234\.*/], {
-    endpoint: "http://localhost:5678/v1/traces",
+    proxy: "http://localhost:5678/v1/traces",
     debug: true
 });
 

--- a/samples/proxy/express-proxy/src/index.ts
+++ b/samples/proxy/express-proxy/src/index.ts
@@ -1,6 +1,6 @@
 import cors from "cors";
 import * as dotenv from "dotenv";
-import express, { type Request, type Response } from "express";
+import express, { json, type Request, type Response } from "express";
 import path from "node:path";
 
 dotenv.config({
@@ -10,8 +10,13 @@ dotenv.config({
 const app = express();
 const port = 5678;
 
-app.use(express.json());
-app.use(cors());
+app.use(json());
+
+app.use(cors({
+    origin: ["http://localhost:8080"],
+    methods: ["POST"],
+    credentials: true
+}));
 
 app.listen(port, () => {
     console.log(`[server]: Server is running at http://localhost:${port}`);


### PR DESCRIPTION
- Renamed `endpoint` for `proxy`
- When a `proxy` option is provided, traces automatically includes the current session credentials